### PR TITLE
Add a default filter value for all alerts

### DIFF
--- a/library/logzio_alert.py
+++ b/library/logzio_alert.py
@@ -159,6 +159,8 @@ class LogzioAlertConfiguration(object):
         self.valueAggregationField = configuration['valueAggregationField']
         self.groupByAggregationFields = configuration['groupByAggregationFields']
         self.alertNotificationEndpoints = configuration['alertNotificationEndpoints']
+        # Add the filter field by default because the Logz.io does not use a default value for it.
+        self.filter = "{\"bool\":{\"must\":[],\"must_not\":[]}}"
 
     def validate(self):
         if self.valueAggregationType not in [None, 'NONE'] and self.valueAggregationField is None:


### PR DESCRIPTION
In order to not break alerts when creating them. The default filter value is needed because the Logz.io API currently does not set it by default, but the web interface does.